### PR TITLE
feat(kyverno): add verifyImages and cleanup lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,13 +401,17 @@ To demonstrate policy-to-enforcement capability beyond CI, CertGuard includes a 
 - `deployments/kyverno/cert-validity-check.yaml`
 - `deployments/kyverno/default-cert-duration.yaml`
 - `deployments/kyverno/generate-namespace-networkpolicy.yaml`
+- `deployments/kyverno/verify-image-signatures.yaml`
+- `deployments/kyverno/cleanup-failed-cert-requests.yaml`
 - `deployments/kyverno/tests/kyverno-test.yaml`
 
-These policies cover validation, mutation, and generation patterns:
+These policies cover validation, mutation, generation, supply-chain verification, and lifecycle cleanup:
 
 - validate cert-manager `Certificate` duration against `2160h` (90 days)
 - mutate missing certificate durations to a secure default
 - generate namespace-level default-deny network controls for secure-by-default onboarding
+- verify signed container images at admission using Kyverno `verifyImages`
+- clean up failed certificate requests marked for automated deletion
 
 Kyverno CLI tests run in CI via `.github/workflows/kyverno-policy.yml` to enforce shift-left policy checks before merge.
 
@@ -421,6 +425,15 @@ Use this as a runtime complement to CertGuard's CI compliance gate.
 Policy report visibility guidance:
 
 - `docs/KYVERNO_POLICY_REPORTING.md`
+
+### Example Kyverno Supply Chain Output
+
+```text
+policy: verify-signed-container-images
+rule: require-signed-images
+resource: Pod/signed-image-pod -> PASS
+resource: Pod/unsigned-image-pod -> FAIL (signature verification failed)
+```
 
 ---
 

--- a/deployments/kyverno/README.md
+++ b/deployments/kyverno/README.md
@@ -14,6 +14,12 @@ This directory contains Kubernetes admission policies that mirror CertGuard cont
 - `generate-namespace-networkpolicy.yaml`
   - generates a default-deny `NetworkPolicy` when new namespaces are created
   - demonstrates secure-by-default multi-tenant platform patterns
+- `verify-image-signatures.yaml`
+  - verifies signatures for container images from controlled repositories
+  - demonstrates supply chain integrity controls at admission time
+- `cleanup-failed-cert-requests.yaml`
+  - deletes failed `CertificateRequest` resources marked for cleanup
+  - demonstrates lifecycle hygiene for high-volume issuance pipelines
 
 ## Shift-Left Testing
 
@@ -47,6 +53,15 @@ See `docs/KYVERNO_POLICY_REPORTING.md` for commands and usage examples with:
 - `ClusterPolicyReport`
 - `PolicyReport`
 - `kubectl` report inspection flow
+
+## Supply Chain Security Signal
+
+The `verify-image-signatures.yaml` policy uses `verifyImages` to ensure workloads are signed before admission.
+
+Example outcomes in test mode:
+
+- `signed-image-pod`: pass
+- `unsigned-image-pod`: fail
 
 ## Why This Matters
 

--- a/deployments/kyverno/cleanup-failed-cert-requests.yaml
+++ b/deployments/kyverno/cleanup-failed-cert-requests.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v2
+kind: ClusterCleanupPolicy
+metadata:
+  name: cleanup-failed-certificate-requests
+  annotations:
+    policies.kyverno.io/title: Cleanup failed certificate requests
+    policies.kyverno.io/category: PKI Lifecycle Hygiene
+spec:
+  schedule: "0 */6 * * *"
+  match:
+    any:
+      - resources:
+          kinds:
+            - CertificateRequest
+          selector:
+            matchLabels:
+              certguard.io/cleanup: "true"
+  conditions:
+    any:
+      - key: "{{ target.status.conditions[?type=='Ready'][0].status || '' }}"
+        operator: Equals
+        value: "False"

--- a/deployments/kyverno/tests/kyverno-test.yaml
+++ b/deployments/kyverno/tests/kyverno-test.yaml
@@ -6,11 +6,14 @@ policies:
   - ../cert-validity-check.yaml
   - ../default-cert-duration.yaml
   - ../generate-namespace-networkpolicy.yaml
+  - ../verify-image-signatures.yaml
 resources:
   - resources/certificate-valid.yaml
   - resources/certificate-too-long.yaml
   - resources/certificate-missing-duration.yaml
   - resources/namespace-team-a.yaml
+  - resources/pod-signed-image.yaml
+  - resources/pod-unsigned-image.yaml
 results:
   - policy: enforce-90-day-max-validity
     rule: check-cert-expiry
@@ -36,3 +39,15 @@ results:
       - team-a
     kind: Namespace
     result: pass
+  - policy: verify-signed-container-images
+    rule: require-signed-images
+    resources:
+      - signed-image-pod
+    kind: Pod
+    result: pass
+  - policy: verify-signed-container-images
+    rule: require-signed-images
+    resources:
+      - unsigned-image-pod
+    kind: Pod
+    result: fail

--- a/deployments/kyverno/tests/resources/pod-signed-image.yaml
+++ b/deployments/kyverno/tests/resources/pod-signed-image.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: signed-image-pod
+  namespace: certguard-system
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/test-verify-image:signed

--- a/deployments/kyverno/tests/resources/pod-unsigned-image.yaml
+++ b/deployments/kyverno/tests/resources/pod-unsigned-image.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unsigned-image-pod
+  namespace: certguard-system
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/test-verify-image:unsigned

--- a/deployments/kyverno/verify-image-signatures.yaml
+++ b/deployments/kyverno/verify-image-signatures.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-signed-container-images
+  annotations:
+    policies.kyverno.io/title: Verify signed container images
+    policies.kyverno.io/category: Supply Chain Security
+spec:
+  validationFailureAction: Audit
+  background: false
+  webhookTimeoutSeconds: 30
+  failurePolicy: Fail
+  rules:
+    - name: require-signed-images
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/kyverno/test-verify-image:*"
+          mutateDigest: false
+          verifyDigest: false
+          required: true
+          attestors:
+            - count: 1
+              entries:
+                - keys:
+                    publicKeys: |-
+                      -----BEGIN PUBLIC KEY-----
+                      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+                      5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+                      -----END PUBLIC KEY-----

--- a/deployments/kyverno/verify-image-signatures.yaml
+++ b/deployments/kyverno/verify-image-signatures.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   validationFailureAction: Audit
   background: false
-  webhookTimeoutSeconds: 30
-  failurePolicy: Fail
   rules:
     - name: require-signed-images
       match:
@@ -19,10 +17,8 @@ spec:
                 - Pod
       verifyImages:
         - imageReferences:
-            - "ghcr.io/kyverno/test-verify-image:*"
-          mutateDigest: false
-          verifyDigest: false
-          required: true
+            - "ghcr.io/kyverno/test-verify-image*"
+          mutateDigest: true
           attestors:
             - count: 1
               entries:

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -63,3 +63,4 @@ This document tracks implemented capabilities in a detailed, phase-oriented form
   - crypto transition checks added (validity target, RSA target, approved signature hash allowlist)
   - dedicated profile added: `policies/profiles/crypto_agility_pqc_readiness.yaml`
   - Kyverno lifecycle coverage added (validation, mutation, generation, CLI tests, policy reporting guidance)
+  - Kyverno supply chain and lifecycle hygiene controls added (`verifyImages` and `ClusterCleanupPolicy`)


### PR DESCRIPTION
## Summary
- add `verify-image-signatures.yaml` using Kyverno `verifyImages` with public-key attestor for signed image admission checks
- extend Kyverno test suite with signed/unsigned pod fixtures to show supply-chain pass/fail outcomes
- add `cleanup-failed-cert-requests.yaml` and update docs (`README.md`, `deployments/kyverno/README.md`, `docs/PROJECT_STATUS.md`) for reporting and lifecycle hygiene visibility

## Test plan
- [ ] GitHub Actions: `Kyverno Policy Tests` passes on this PR
- [ ] Confirm signed fixture `signed-image-pod` reports pass and unsigned fixture reports fail in Kyverno test output
- [ ] Confirm README sections render and list new policies accurately

Made with [Cursor](https://cursor.com)