### PR TITLE
ci(artifacts): add workflow artifacts for all runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,3 +33,23 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+
+      - name: Capture CodeQL run metadata
+        if: always()
+        run: |
+          mkdir -p artifacts/codeql
+          {
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "workflow=${GITHUB_WORKFLOW}"
+            echo "ref=${GITHUB_REF}"
+            echo "sha=${GITHUB_SHA}"
+          } > artifacts/codeql/codeql-run-metadata.txt
+
+      - name: Upload CodeQL run artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: codeql-run-artifacts-${{ github.run_id }}
+          path: artifacts/codeql
+          if-no-files-found: warn

--- a/.github/workflows/kyverno-policy.yml
+++ b/.github/workflows/kyverno-policy.yml
@@ -28,4 +28,16 @@ jobs:
         run: kyverno version
 
       - name: Run Kyverno test suite
-        run: kyverno test deployments/kyverno/tests
+        run: |
+          mkdir -p artifacts/kyverno
+          set -o pipefail
+          kyverno test deployments/kyverno/tests --detailed-results \
+            | tee artifacts/kyverno/kyverno-test-results.txt
+
+      - name: Upload Kyverno test artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kyverno-policy-test-artifacts-${{ github.run_id }}
+          path: artifacts/kyverno
+          if-no-files-found: warn

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -25,9 +25,22 @@ jobs:
           pip install bandit pip-audit
 
       - name: Run Bandit (SAST)
-        run: bandit -r src -q
+        run: |
+          mkdir -p artifacts/security
+          set -o pipefail
+          bandit -r src -q | tee artifacts/security/bandit-report.txt
 
       - name: Run pip-audit (dependency vulnerabilities)
         run: |
+          set -o pipefail
           # Temporary exception until an upstream pygments fix is published.
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539
+          pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539 \
+            | tee artifacts/security/pip-audit-report.txt
+
+      - name: Upload security scan artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-scan-artifacts-${{ github.run_id }}
+          path: artifacts/security
+          if-no-files-found: warn

--- a/.github/workflows/standards-sync.yml
+++ b/.github/workflows/standards-sync.yml
@@ -43,3 +43,19 @@ jobs:
           branch: chore/standards-sync
           base: main
           delete-branch: true
+
+      - name: Capture sync artifacts
+        if: always()
+        run: |
+          mkdir -p artifacts/standards-sync
+          cp policies/standards_baseline.yaml artifacts/standards-sync/ 2>/dev/null || true
+          cp policies/standards_sync_snapshot.yaml artifacts/standards-sync/ 2>/dev/null || true
+          git status --short > artifacts/standards-sync/git-status.txt
+
+      - name: Upload standards sync artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: standards-sync-artifacts-${{ github.run_id }}
+          path: artifacts/standards-sync
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add artifact upload to `Kyverno Policy Tests` with detailed Kyverno CLI output
- add artifact upload to `Security Scans` for Bandit and pip-audit logs
- add artifact upload to `CodeQL` with run metadata snapshot
- add artifact upload to `Standards Sync` for baseline/snapshot files and git status output

## Why
This makes each workflow run leave downloadable evidence for troubleshooting, audit traceability, and demo-friendly reporting.

## Notes
- `Compliance Gate` and `Docs Render` already published artifacts; these remain unchanged.
- Existing pass/fail behavior is preserved.

Made with [Cursor](https://cursor.com)