### PR TITLE
test+policy: add parser and fixture tests, harden CABF policy definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ reports/*.seal
 reports/*.md
 audit_evidence/*.json
 audit_evidence/*.jsonl
+
+# Private learning materials (not for public repo)
+docs/COMMANDS_AND_LEARNING_GUIDE.md
+docs/DEMO_SCRIPT.md

--- a/README.md
+++ b/README.md
@@ -474,17 +474,22 @@ Fixture matrix validation:
 
 ## Roadmap
 
-- **Phase 4 (enterprise alignment): completed**
-- **Phase 5: Crypto-Agility & Post-Quantum Readiness (in progress)**
+- **Phase 1-4 (core engine through enterprise alignment): completed**
+- **Phase 5: Crypto-Agility & Post-Quantum Readiness: completed**
+  - crypto transition policy fields and validator checks
+  - dedicated crypto-agility profile (`crypto_agility_pqc_readiness.yaml`)
+  - supply-chain image verification (Kyverno `verifyImages`)
+  - lifecycle cleanup policies (Kyverno `ClusterCleanupPolicy`)
+  - Ed25519-signed release provenance with in-CI verification
+  - append-only hash-chained compliance decision log
 
 Detailed implementation history and capability tracking lives in:
 
 - `docs/PROJECT_STATUS.md`
 
-Planned in next phase:
+Next:
 
-- **Expand crypto transition readiness** (algorithm agility controls, migration profiles, and evidence hooks)
-- **Add crypto transition evidence snapshots** for long-running readiness tracking
+- **Phase 6 (hardening):** expand test coverage for parser edge cases and fixture matrix, harden policy definitions with CABF BR term references
 
 ---
 

--- a/policies/cabf_policy.yaml
+++ b/policies/cabf_policy.yaml
@@ -4,7 +4,25 @@ metadata:
   last_updated: "2026-03-16"
   terms: "CABF Baseline Requirements policy profile for CertGuard MVP"
 
-terms: []
+terms:
+  - id: "CABF-BR-6.3.2"
+    title: "Certificate Validity Period"
+    summary: "Subscriber certificates SHALL NOT exceed 398 days; CertGuard MVP uses 200 days."
+  - id: "CABF-BR-7.1.2"
+    title: "Subject Alternative Name Required"
+    summary: "All certificates MUST include at least one SAN value."
+  - id: "CABF-BR-7.1.3"
+    title: "Prohibited Signature Algorithms"
+    summary: "SHA-1 and MD5 SHALL NOT be used for signing subscriber certificates."
+  - id: "CABF-BR-6.1.5"
+    title: "Minimum Key Size"
+    summary: "RSA keys MUST be at least 2048 bits."
+  - id: "CABF-BR-7.1.4.2"
+    title: "Internal Name Prohibition"
+    summary: "Certificates SHALL NOT contain internal server names or reserved IP addresses."
+  - id: "CABF-BR-3.2.2.4"
+    title: "Domain Control Validation"
+    summary: "CAs MUST verify applicant control of the domain using approved DCV methods."
 
 certificate:
   max_validity_days: 200
@@ -50,7 +68,11 @@ rfc5280:
     - "key_encipherment"
   require_subject_key_identifier: false
   require_authority_key_identifier: false
-  allowed_critical_extensions: []
+  allowed_critical_extensions:
+    - "2.5.29.15"   # Key Usage
+    - "2.5.29.19"   # Basic Constraints
+    - "2.5.29.17"   # Subject Alternative Name (when marked critical)
+    - "2.5.29.32"   # Certificate Policies
   require_path_issuer_subject_match: false
   require_path_aki_ski_match: false
 

--- a/tests/test_fixture_compliance.py
+++ b/tests/test_fixture_compliance.py
@@ -1,0 +1,75 @@
+"""Engine-level compliance assertions for every prebuilt certificate fixture.
+
+Each test validates the expected pass/fail outcome directly through
+ComplianceGateEngine, complementing the CI fixture-matrix job with
+in-repo pytest coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from certguard.engine import ComplianceGateEngine
+
+POLICY_PATH = Path("policies/cabf_policy.yaml")
+FIXTURES_DIR = Path("tests/certificates")
+
+
+def _evaluate_fixture(fixture_name: str, tmp_path: Path) -> dict:
+    cert_path = FIXTURES_DIR / fixture_name
+    report_path = tmp_path / "report.json"
+    evidence_dir = tmp_path / "evidence"
+    engine = ComplianceGateEngine(policy_path=POLICY_PATH)
+    compliant, _ = engine.evaluate(cert_path, report_path, evidence_dir)
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["_compliant_result"] = compliant
+    return report
+
+
+def test_valid_cert_is_compliant(tmp_path: Path) -> None:
+    report = _evaluate_fixture("valid_cert.pem", tmp_path)
+    assert report["_compliant_result"] is True
+    assert report["compliant"] is True
+    assert report["score"] == 100.0
+    assert report["risk_level"] == "LOW"
+
+
+def test_sha1_cert_fails_signature_algorithm(tmp_path: Path) -> None:
+    report = _evaluate_fixture("sha1_cert.pem", tmp_path)
+    assert report["_compliant_result"] is False
+    sig_check = next(c for c in report["checks"] if c["name"] == "signature_algorithm")
+    assert sig_check["status"] == "fail"
+    assert sig_check["severity"] == "critical"
+    assert report["risk_level"] == "HIGH"
+
+
+def test_long_validity_cert_fails_max_days(tmp_path: Path) -> None:
+    report = _evaluate_fixture("long_validity_cert.pem", tmp_path)
+    assert report["_compliant_result"] is False
+    validity_check = next(c for c in report["checks"] if c["name"] == "validity_days")
+    assert validity_check["status"] == "fail"
+
+
+def test_no_san_cert_fails_san_requirement(tmp_path: Path) -> None:
+    report = _evaluate_fixture("no_san_cert.pem", tmp_path)
+    assert report["_compliant_result"] is False
+    san_check = next(c for c in report["checks"] if c["name"] == "san_extension")
+    assert san_check["status"] == "fail"
+
+
+def test_internal_domain_cert_fails_domain_check(tmp_path: Path) -> None:
+    report = _evaluate_fixture("internal_domain_cert.pem", tmp_path)
+    assert report["_compliant_result"] is False
+    domain_check = next(c for c in report["checks"] if c["name"] == "internal_domain_check")
+    assert domain_check["status"] == "fail"
+
+
+def test_weak_key_cert_fails_rsa_key_size(tmp_path: Path) -> None:
+    report = _evaluate_fixture("weak_key_cert.pem", tmp_path)
+    assert report["_compliant_result"] is False
+    key_check = next(c for c in report["checks"] if c["name"] == "rsa_key_size")
+    assert key_check["status"] == "fail"
+    assert key_check["severity"] == "critical"

--- a/tests/test_x509_parser.py
+++ b/tests/test_x509_parser.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+
+from certguard.agents.x509_parser import X509ParserAgent
+
+
+def _write_cert(
+    path: Path,
+    *,
+    common_name: str = "example.com",
+    san_dns: list[str] | None = None,
+    days: int = 90,
+    rsa_bits: int = 2048,
+    hash_algo: hashes.HashAlgorithm = hashes.SHA256(),
+    include_san: bool = True,
+    include_ski: bool = False,
+    include_basic_constraints: bool = False,
+    is_ca: bool = False,
+    use_ec: bool = False,
+) -> None:
+    if use_ec:
+        key = ec.generate_private_key(ec.SECP256R1())
+    else:
+        key = rsa.generate_private_key(public_exponent=65537, key_size=rsa_bits)
+
+    now = datetime.now(timezone.utc)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=days))
+    )
+    if include_san:
+        dns_names = san_dns or [common_name]
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(d) for d in dns_names]),
+            critical=False,
+        )
+    if include_ski:
+        builder = builder.add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+    if include_basic_constraints:
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=is_ca, path_length=None),
+            critical=True,
+        )
+
+    cert = builder.sign(private_key=key, algorithm=hash_algo)
+    path.write_bytes(cert.public_bytes(Encoding.PEM))
+
+
+def test_parser_extracts_subject_and_issuer(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, common_name="test.example.com")
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.success is True
+    assert "test.example.com" in result.data["subject"]
+    assert "test.example.com" in result.data["issuer"]
+    assert result.data["common_name"] == "test.example.com"
+
+
+def test_parser_extracts_validity_window(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, days=365)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.success is True
+    assert result.data["validity_days"] == 365
+
+
+def test_parser_extracts_san_values(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, san_dns=["a.example.com", "b.example.com"])
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["san_dns"] == ["a.example.com", "b.example.com"]
+
+
+def test_parser_returns_empty_san_when_extension_missing(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, include_san=False)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.success is True
+    assert result.data["san_dns"] == []
+
+
+def test_parser_detects_rsa_key_size(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, rsa_bits=4096)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["is_rsa"] is True
+    assert result.data["rsa_key_size"] == 4096
+
+
+def test_parser_detects_ec_key_as_non_rsa(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, use_ec=True)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["is_rsa"] is False
+    assert result.data["rsa_key_size"] is None
+
+
+def test_parser_extracts_signature_algorithm(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, hash_algo=hashes.SHA384())
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["signature_algorithm"] == "sha384"
+
+
+def test_parser_extracts_ski_when_present(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, include_ski=True)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["has_subject_key_identifier"] is True
+    assert isinstance(result.data["subject_key_identifier"], str)
+    assert len(result.data["subject_key_identifier"]) > 0
+
+
+def test_parser_reports_missing_ski(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, include_ski=False)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["has_subject_key_identifier"] is False
+    assert result.data["subject_key_identifier"] is None
+
+
+def test_parser_extracts_basic_constraints(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, include_basic_constraints=True, is_ca=False)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.data["basic_constraints_ca"] is False
+
+
+def test_parser_extracts_critical_extension_oids(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_cert(cert_path, include_basic_constraints=True, is_ca=True)
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert "2.5.29.19" in result.data["critical_extension_oids"]
+
+
+def test_parser_fails_for_missing_file() -> None:
+    result = X509ParserAgent().run({"cert_path": "/nonexistent/cert.pem"})
+
+    assert result.success is False
+    assert len(result.errors) > 0
+
+
+def test_parser_fails_for_invalid_pem(tmp_path: Path) -> None:
+    cert_path = tmp_path / "bad.pem"
+    cert_path.write_text("not a real certificate", encoding="utf-8")
+
+    result = X509ParserAgent().run({"cert_path": str(cert_path)})
+
+    assert result.success is False
+    assert "PEM" in result.errors[0] or "parse" in result.errors[0].lower()


### PR DESCRIPTION
## Summary

- **13 new X509ParserAgent tests** covering field extraction (subject, issuer, CN, SAN, validity, key size, signature algorithm, SKI, basic constraints, critical OIDs), edge cases (EC keys, missing extensions), and error paths (missing file, invalid PEM)
- **6 new fixture compliance tests** asserting engine-level outcomes for every prebuilt certificate fixture (`valid_cert`, `sha1_cert`, `long_validity_cert`, `no_san_cert`, `internal_domain_cert`, `weak_key_cert`)
- **Hardened `cabf_policy.yaml`**: populated `terms` with CABF BR section references (6.3.2, 7.1.2, 7.1.3, 6.1.5, 7.1.4.2, 3.2.2.4) and filled `allowed_critical_extensions` with correct OIDs
- **Updated README roadmap**: Phase 5 marked completed with all delivered capabilities listed
- **Private learning docs**: added `docs/COMMANDS_AND_LEARNING_GUIDE.md` and `docs/DEMO_SCRIPT.md` to `.gitignore`

Test count: 45 → 64

## Test plan

- [x] All 64 tests pass locally (`pytest tests/ -v`)
- [ ] CI compliance workflow passes
- [ ] CI security scans pass
- [ ] Kyverno policy tests pass

Made with [Cursor](https://cursor.com)