### PR TITLE
chore: clean up project structure and refresh documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 venv/
 __pycache__/
 *.pyc
+.pytest_cache/
 .DS_Store
 reports/*.json
 reports/*.digest

--- a/README.md
+++ b/README.md
@@ -35,35 +35,16 @@ It is designed to demonstrate how compliance requirements translate into executa
 
 ---
 
-## Why This Project
-
-For certificate ecosystems, one non-compliant issuance can create significant operational and trust risk.  
-This project demonstrates a shift-left compliance model:
-
-- **Policy-as-code:** rules are configurable and traceable
-- **Governance gate:** pipeline blocks violations
-- **Audit evidence:** JSON outputs support review and assurance workflows
-- **Engineering discipline:** testable, repeatable, CI-driven validation
-
----
-
 ## Why This Matters
 
-A single non-compliant certificate can:
+A single non-compliant certificate can break browser trust, cause production outages, or introduce avoidable security risk. In CA environments, pre-issuance compliance controls ensure certificates meet industry standards before they are trusted.
 
-- break browser trust
-- cause production outages
-- introduce avoidable security risk
+CertGuard enforces compliance before issuance, not after failure, using a shift-left model:
 
-CertGuard helps prevent this by enforcing compliance before issuance, not after failure.
-
----
-
-## Security Context
-
-In certificate authority environments, pre-issuance compliance controls help ensure certificates meet industry standards before they are trusted by browsers and operating systems.
-
-CertGuard Engine simulates this style of control pipeline by converting policy requirements into automated validation checks, governance decisions, and audit evidence outputs.
+- **Policy-as-code:** rules are configurable, traceable, and version-controlled
+- **Governance gate:** pipeline blocks violations with severity-based exit codes
+- **Audit evidence:** JSON outputs support review, assurance, and audit workflows
+- **Engineering discipline:** testable, repeatable, CI-driven validation
 
 ---
 
@@ -292,7 +273,7 @@ Severity-based exit codes (`evaluate` mode):
 
 - `0` = fully compliant
 - `1` = low severity failures
-- `2` = medium/high severity failures
+- `2` = medium/high severity failures, or lint-only failure
 - `3` = critical failures
 
 ---
@@ -443,13 +424,16 @@ Workflow: `.github/workflows/compliance.yml`
 
 Pipeline actions:
 
-1. Install dependencies
-2. Execute `pytest`
+1. Install dependencies + zlint + OPA binaries
+2. Execute `pytest` (64 tests)
 3. Generate sample certificate
-4. Run compliance gate
-5. Generate CycloneDX SBOM
-6. Generate signed release provenance + verification
-7. Upload compliance artifacts
+4. Run compliance gate (standard profile)
+5. Run compliance gate with zlint + OPA enabled (`ci_lint_gate` profile)
+6. Verify zlint and OPA executed (not skipped)
+7. Generate reviewer summary + trend snapshot
+8. Generate CycloneDX SBOM
+9. Generate Ed25519-signed release provenance + in-CI verification
+10. Upload compliance artifact bundle
 
 This creates visible governance evidence directly in GitHub Actions.
 

--- a/docs/EVIDENCE_LIFECYCLE.md
+++ b/docs/EVIDENCE_LIFECYCLE.md
@@ -6,13 +6,30 @@ This document defines how compliance evidence is generated, named, retained, and
 
 CI bundles evidence under a run-specific path:
 
+### Compliance report and governance outputs
+
 - `artifacts/<github_run_id>/compliance_report.json`
 - `artifacts/<github_run_id>/compliance_report.json.seal`
 - `artifacts/<github_run_id>/compliance_summary.md`
 - `artifacts/<github_run_id>/compliance_trend_snapshot.json`
+
+### Audit evidence
+
 - `artifacts/<github_run_id>/policy_checks.json`
 - `artifacts/<github_run_id>/lint_results.json`
+- `artifacts/<github_run_id>/waiver_results.json`
+- `artifacts/<github_run_id>/opa_results.json`
 - `artifacts/<github_run_id>/evidence_manifest.json`
+- `artifacts/<github_run_id>/compliance_decisions.jsonl`
+
+### Supply chain and provenance
+
+- `artifacts/<github_run_id>/sbom.cdx.json`
+- `artifacts/<github_run_id>/release_provenance.json`
+- `artifacts/<github_run_id>/release_provenance.json.digest`
+- `artifacts/<github_run_id>/release_provenance.json.sig`
+- `artifacts/<github_run_id>/release_provenance.json.sig.meta.json`
+- `artifacts/<github_run_id>/release_signing_public_key.b64`
 
 This provides deterministic traceability from evidence to workflow execution context.
 
@@ -24,8 +41,11 @@ This provides deterministic traceability from evidence to workflow execution con
 
 ## Review Workflow
 
-1. Verify `compliance_report.json` and status.
+1. Verify `compliance_report.json` and compliance status.
 2. Verify integrity seal (`compliance_report.json.seal`).
-3. Verify control detail outputs (`policy_checks.json`, `lint_results.json`).
-4. Review trend signal (`compliance_trend_snapshot.json`).
-5. Record reviewer note in PR or issue using `compliance_summary.md`.
+3. Verify control detail outputs (`policy_checks.json`, `lint_results.json`, `opa_results.json`).
+4. Verify waiver application (`waiver_results.json`).
+5. Review decision log integrity (`compliance_decisions.jsonl` hash chain).
+6. Review trend signal (`compliance_trend_snapshot.json`).
+7. Verify release provenance signature (`release_provenance.json.sig` against public key).
+8. Record reviewer note in PR or issue using `compliance_summary.md`.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -46,7 +46,7 @@ This document tracks implemented capabilities in a detailed, phase-oriented form
 
 `README.md` stays concise for first-time readers, while this file preserves full implementation detail for reviewers, hiring managers, and audit-minded stakeholders.
 
-## Upcoming Work
+## Completed Phases
 
 - **Phase 4 (enterprise alignment) - completed**
   - APISEC expanded with TLS version policy checks, cipher posture checks, and chain posture signals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Remove empty legacy directories (`src/engine/`, `src/parser/`, `src/rules/`) and duplicate `venv/`
- Add `.pytest_cache/` to `.gitignore` to prevent accidental commits
- Add `pyproject.toml` with pytest `pythonpath` config — eliminates need for manual `PYTHONPATH=src`
- Add `reports/.gitkeep` for directory consistency with `audit_evidence/`
- Consolidate three redundant README sections ("Why This Project", "Why This Matters", "Security Context") into one
- Update README CI pipeline description to reflect zlint + OPA integration (10 steps)
- Fix `PROJECT_STATUS.md` misleading "Upcoming Work" heading (everything listed is completed)
- Update `EVIDENCE_LIFECYCLE.md` from 7 artifacts to full 16-artifact bundle with categorized sections
- Update exit code docs to note lint-only failures map to exit 2

Also updated (local-only, gitignored):
- `COMMANDS_AND_LEARNING_GUIDE.md` — CI workflow section now covers zlint/OPA install, verification step, and interview Q&A
- `DEMO_SCRIPT.md` — CI section and zlint Q&A now reference proven integration

## Test plan

- [x] 64 Python tests pass locally
- [ ] CI compliance gate passes
- [ ] CI security scans pass
- [ ] No new linter warnings


Made with [Cursor](https://cursor.com)