### PR TITLE
test(apisec): make expiry assertions deterministic

### DIFF
--- a/tests/test_apisec.py
+++ b/tests/test_apisec.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 import ssl
+from datetime import datetime, timedelta
 from pathlib import Path
 
+import certguard.agents.api_tls_posture as api_tls_module
 from certguard.agents.api_tls_posture import ApiTlsPostureAgent
 
 
 def test_apisec_agent_low_risk_for_valid_fixture(monkeypatch) -> None:
     pem = Path("tests/certificates/valid_cert.pem").read_text(encoding="utf-8")
+    cert = api_tls_module.x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    fixed_now = cert.not_valid_after_utc - timedelta(days=60)
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
     agent = ApiTlsPostureAgent()
+    monkeypatch.setattr(api_tls_module, "datetime", FrozenDateTime)
     monkeypatch.setattr(
         agent,
         "_fetch_tls_posture",
@@ -23,6 +36,39 @@ def test_apisec_agent_low_risk_for_valid_fixture(monkeypatch) -> None:
     assert result.success is True
     assert result.data["risk_level"] == "LOW"
     assert result.data["tls_version"] == "TLSv1.3"
+
+
+def test_apisec_agent_expiring_fixture_is_expected_to_fail(monkeypatch) -> None:
+    pem = Path("tests/certificates/valid_cert.pem").read_text(encoding="utf-8")
+    cert = api_tls_module.x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    fixed_now = cert.not_valid_after_utc - timedelta(days=10)
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
+    agent = ApiTlsPostureAgent()
+    monkeypatch.setattr(api_tls_module, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        agent,
+        "_fetch_tls_posture",
+        lambda host, port: {
+            "certificate_pem": pem,
+            "tls_version": "TLSv1.3",
+            "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        },
+    )
+
+    result = agent.run({"endpoint": "https://api.example.com"})
+    assert result.success is False
+    assert result.data["risk_level"] == "MEDIUM"
+    expiry_check = next(
+        check for check in result.checks if check.name == "endpoint_certificate_expiry"
+    )
+    assert expiry_check.status == "fail"
 
 
 def test_apisec_agent_high_risk_for_sha1_fixture(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- make APISEC low-risk fixture test deterministic by freezing time relative to cert expiry
- add explicit expected-fail coverage for near-expiry certificates to model real-world behavior
- prevent schedule-based CI failures caused by fixture age drift

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_apisec.py`
- [x] `.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)