### PR TITLE
fix(ci): enable downstream checks on standards-sync PRs

### DIFF
--- a/.github/workflows/standards-sync.yml
+++ b/.github/workflows/standards-sync.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Create pull request if sync changed
         uses: peter-evans/create-pull-request@v8
         with:
+          # Use a repo secret token (classic PAT or fine-grained PAT) so follow-up
+          # PR workflows (Compliance Gate, Security Scans) trigger automatically.
+          # If not configured, fallback to github.token (checks may not auto-trigger).
+          token: ${{ secrets.STANDARDS_SYNC_PR_TOKEN != '' && secrets.STANDARDS_SYNC_PR_TOKEN || github.token }}
           commit-message: "chore(standards): sync CAB Forum baseline snapshot"
           title: "chore(standards): sync CAB Forum baseline snapshot"
           body: |
@@ -57,6 +61,7 @@ jobs:
             - sync CA/B Forum BR snapshot from upstream source
             - refresh `policies/standards_baseline.yaml`
             - update generated `policies/standards_sync_snapshot.yaml`
+            - note: auto-run PR checks require `STANDARDS_SYNC_PR_TOKEN` secret
           branch: chore/standards-sync
           base: main
           delete-branch: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,9 @@ python src/main.py --mode apisec --endpoint https://example.com
 - `standards-pr-guard.yml`
 - `kyverno-policy.yml`
 - `docs-render.yml`
+
+## Automation Secrets
+
+- `STANDARDS_SYNC_PR_TOKEN`: token used by `standards-sync.yml` when creating bot PRs.
+  Configure this secret so downstream PR workflows (`Compliance Gate`, `Security Scans`)
+  auto-trigger on standards-sync pull requests.


### PR DESCRIPTION
## Summary
- configure standards-sync PR creation to use `STANDARDS_SYNC_PR_TOKEN` when available
- preserve fallback to `github.token` with explicit note about check-trigger limitations
- document required automation secret in `CONTRIBUTING.md`

## Why
GitHub does not trigger downstream workflows from PRs created by `github.token` in automation. Using a dedicated token restores automatic `Compliance Gate` and `Security Scans` runs for future standards-sync PRs.

## Setup required
- Add repo secret: `STANDARDS_SYNC_PR_TOKEN`
- Token scopes: `repo`, `read:org`, `gist` (same as existing automation usage)

## Test plan
- [x] Validate `standards-sync.yml` YAML parses
- [ ] Confirm next standards-sync PR auto-runs Compliance Gate + Security Scans

Made with [Cursor](https://cursor.com)