### PR TITLE
chore(standards): sync CAB Forum baseline snapshot

### DIFF
--- a/policies/standards_baseline.yaml
+++ b/policies/standards_baseline.yaml
@@ -1,8 +1,8 @@
 terms: []
 baseline:
   source: CA/Browser Forum BR (auto-synced)
-  version: 2026.06.09
-  last_reviewed: '2026-06-09'
+  version: 2026.06.16
+  last_reviewed: '2026-06-16'
   references:
   - CAB Forum Baseline Requirements
   - RFC 5280

--- a/policies/standards_sync_snapshot.yaml
+++ b/policies/standards_sync_snapshot.yaml
@@ -1,7 +1,7 @@
 sync:
-  fetched_at: '2026-06-09T08:55:09.331746+00:00'
-  source_url: https://raw.githubusercontent.com/cabforum/servercert/1bcb34993331313c92ac7d6af778e81ca3d5faff/docs/BR.md
-  source_sha256: 88d39d1646dfb0279f7f1e42c5227d2f70c27310979863225e91e99bb45bfad8
+  fetched_at: '2026-06-16T10:48:54.152154+00:00'
+  source_url: https://raw.githubusercontent.com/cabforum/servercert/9270ad7887b48d58bf0954336de32c265a934d66/docs/BR.md
+  source_sha256: a29be59f0ae0485be505f30281b356a0efef2a2ad442daf9a9f161f2df238f67
 extracted:
   validity_day_values:
   - 10


### PR DESCRIPTION
## Summary
- sync CA/B Forum BR snapshot from upstream source
- refresh `policies/standards_baseline.yaml`
- update generated `policies/standards_sync_snapshot.yaml`
- note: auto-run PR checks require `STANDARDS_SYNC_PR_TOKEN` secret