### PR TITLE
chore(standards): sync CAB Forum baseline snapshot

### DIFF
--- a/policies/standards_baseline.yaml
+++ b/policies/standards_baseline.yaml
@@ -1,8 +1,8 @@
 terms: []
 baseline:
   source: CA/Browser Forum BR (auto-synced)
-  version: 2026.06.23
-  last_reviewed: '2026-06-23'
+  version: 2026.07.07
+  last_reviewed: '2026-07-07'
   references:
   - CAB Forum Baseline Requirements
   - RFC 5280

--- a/policies/standards_sync_snapshot.yaml
+++ b/policies/standards_sync_snapshot.yaml
@@ -1,6 +1,6 @@
 sync:
-  fetched_at: '2026-06-23T08:53:28.985934+00:00'
-  source_url: https://raw.githubusercontent.com/cabforum/servercert/9270ad7887b48d58bf0954336de32c265a934d66/docs/BR.md
+  fetched_at: '2026-07-07T09:18:36.705882+00:00'
+  source_url: https://raw.githubusercontent.com/cabforum/servercert/a0f0a3ca5dfeaa53c682dded3d0d9dd49e3609b7/docs/BR.md
   source_sha256: a29be59f0ae0485be505f30281b356a0efef2a2ad442daf9a9f161f2df238f67
 extracted:
   validity_day_values:


### PR DESCRIPTION
## Summary
- sync CA/B Forum BR snapshot from upstream source
- refresh `policies/standards_baseline.yaml`
- update generated `policies/standards_sync_snapshot.yaml`
- note: auto-run PR checks require `STANDARDS_SYNC_PR_TOKEN` secret