### PR TITLE
ci(docs): publish pytest checks and document test evidence

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 concurrency:
   group: compliance-${{ github.workflow }}-${{ github.ref }}
@@ -65,6 +66,15 @@ jobs:
             --junitxml=reports/test-results/pytest-junit.xml \
             --html=reports/test-results/pytest-report.html \
             --self-contained-html
+
+      - name: Publish pytest results in checks
+        if: ${{ always() }}
+        uses: dorny/test-reporter@v1
+        with:
+          name: Pytest Results
+          path: reports/test-results/pytest-junit.xml
+          reporter: java-junit
+          fail-on-error: true
 
       - name: Generate sample certificate
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ reports/*.sig.meta.json
 reports/*.b64
 reports/*.seal
 reports/*.md
+reports/test-results/
 audit_evidence/*.json
 audit_evidence/*.jsonl
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ python src/main.py --mode apisec --endpoint https://example.com
 - `audit_evidence/evidence_manifest.json`
 - `audit_evidence/compliance_decisions.jsonl`
 
+## Test Evidence in GitHub
+
+- PR checks: `Compliance Gate` publishes a `Pytest Results` check from JUnit XML.
+- Run artifacts: download `certguard-compliance-artifacts-<run_id>` to get:
+  - `pytest-junit.xml`
+  - `pytest-report.html` (self-contained HTML report)
+- Evidence reports are CI-generated; local `reports/test-results/` is intentionally git-ignored.
+
 ## CI Workflows
 
 - `compliance.yml`


### PR DESCRIPTION
## Summary
- publish JUnit test results into GitHub Checks using `dorny/test-reporter`
- grant `checks: write` permission to `Compliance Gate` for test check publication
- ignore local generated `reports/test-results/` and document where test evidence is visible in GitHub

## Test plan
- [x] Validate workflow YAML parses successfully
- [x] Confirm working tree is clean after commit
- [ ] Confirm PR checks pass in GitHub Actions

Made with [Cursor](https://cursor.com)