### PR TITLE
fix(assurance): recompute compliance from report evidence

### DIFF
--- a/src/certguard/agents/compliance_assurance.py
+++ b/src/certguard/agents/compliance_assurance.py
@@ -26,6 +26,16 @@ class ComplianceAssuranceAgent(BaseAgent):
                 success=False,
                 errors=["Compliance report is missing a valid 'checks' list."],
             )
+        check_map = self._normalize_checks(checks)
+        if check_map is None:
+            return AgentResult(
+                agent=self.name,
+                success=False,
+                errors=[
+                    "Compliance report contains malformed or duplicate checks; assurance "
+                    "requires unique check names and string statuses."
+                ],
+            )
 
         required_controls = context.get(
             "required_controls",
@@ -38,7 +48,6 @@ class ComplianceAssuranceAgent(BaseAgent):
             ],
         )
 
-        check_map = {item.get("name"): item.get("status") for item in checks}
         assurance_checks: list[CheckResult] = []
 
         for control in required_controls:
@@ -62,14 +71,26 @@ class ComplianceAssuranceAgent(BaseAgent):
                 CheckResult(name=f"assure_{control}", status=status, details=details)
             )
 
-        report_compliant = bool(report.get("compliant"))
+        report_compliant = report.get("compliant")
+        if not isinstance(report_compliant, bool):
+            return AgentResult(
+                agent=self.name,
+                success=False,
+                errors=["Compliance report 'compliant' flag must be a boolean value."],
+            )
+        lint_status = self._extract_lint_status(report.get("lint"))
+        expected_compliant = ("fail" not in set(check_map.values())) and lint_status != "fail"
         assurance_checks.append(
             CheckResult(
                 name="assure_final_compliance_flag",
-                status="pass" if report_compliant else "fail",
-                details="Final compliance flag is aligned."
-                if report_compliant
-                else "Final compliance flag indicates non-compliance.",
+                status="pass" if report_compliant == expected_compliant else "fail",
+                details=(
+                    f"Final compliance flag matches independently recomputed outcome "
+                    f"({expected_compliant})."
+                    if report_compliant == expected_compliant
+                    else f"Final compliance flag mismatch: report={report_compliant}, "
+                    f"recomputed={expected_compliant}."
+                ),
             )
         )
 
@@ -83,3 +104,31 @@ class ComplianceAssuranceAgent(BaseAgent):
                 "controls_verified": len(required_controls),
             },
         )
+
+    def _normalize_checks(self, checks: list[Any]) -> dict[str, str] | None:
+        allowed_statuses = {"pass", "fail", "waived"}
+        normalized: dict[str, str] = {}
+        for item in checks:
+            if not isinstance(item, dict):
+                return None
+            name = item.get("name")
+            status = item.get("status")
+            if not isinstance(name, str) or not name.strip():
+                return None
+            if not isinstance(status, str):
+                return None
+            normalized_status = status.strip().lower()
+            if normalized_status not in allowed_statuses:
+                return None
+            if name in normalized:
+                return None
+            normalized[name] = normalized_status
+        return normalized
+
+    def _extract_lint_status(self, lint: Any) -> str | None:
+        if not isinstance(lint, dict):
+            return None
+        status = lint.get("status")
+        if not isinstance(status, str):
+            return None
+        return status.strip().lower()

--- a/tests/test_governance_agents.py
+++ b/tests/test_governance_agents.py
@@ -37,6 +37,58 @@ def test_compliance_assurance_agent_detects_missing_controls() -> None:
     assert len(failed_assurance) >= 1
 
 
+def test_compliance_assurance_agent_detects_flag_mismatch() -> None:
+    agent = ComplianceAssuranceAgent()
+    forged_report = {
+        "compliant": True,
+        "checks": [
+            {"name": "validity_days", "status": "pass", "details": "ok"},
+            {"name": "san_extension", "status": "pass", "details": "ok"},
+            {"name": "rsa_key_size", "status": "pass", "details": "ok"},
+            {"name": "signature_algorithm", "status": "fail", "details": "sha1 detected"},
+            {"name": "internal_domain_check", "status": "pass", "details": "ok"},
+        ],
+    }
+    result = agent.run({"report": forged_report})
+    assert result.success is False
+    flag_check = next(item for item in result.checks if item.name == "assure_final_compliance_flag")
+    assert flag_check.status == "fail"
+    assert "mismatch" in flag_check.details
+
+
+def test_compliance_assurance_agent_rejects_duplicate_check_names() -> None:
+    agent = ComplianceAssuranceAgent()
+    report = {
+        "compliant": True,
+        "checks": [
+            {"name": "validity_days", "status": "pass"},
+            {"name": "validity_days", "status": "fail"},
+        ],
+    }
+    result = agent.run({"report": report})
+    assert result.success is False
+    assert result.errors
+    assert "malformed or duplicate checks" in result.errors[0]
+
+
+def test_compliance_assurance_agent_rejects_non_boolean_compliant_flag() -> None:
+    agent = ComplianceAssuranceAgent()
+    report = {
+        "compliant": "true",
+        "checks": [
+            {"name": "validity_days", "status": "pass"},
+            {"name": "san_extension", "status": "pass"},
+            {"name": "rsa_key_size", "status": "pass"},
+            {"name": "signature_algorithm", "status": "pass"},
+            {"name": "internal_domain_check", "status": "pass"},
+        ],
+    }
+    result = agent.run({"report": report})
+    assert result.success is False
+    assert result.errors
+    assert "must be a boolean value" in result.errors[0]
+
+
 def test_standards_watch_agent_detects_policy_drift() -> None:
     agent = StandardsWatchAgent()
     policy = {


### PR DESCRIPTION
## Summary
- make `ComplianceAssuranceAgent` validate report check structure and reject malformed/duplicate entries
- independently recompute compliance status from check/lint outcomes instead of trusting `report.compliant`
- add adversarial regression tests for forged compliance flag and invalid report shapes

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_governance_agents.py tests/test_phase4_features.py`

Made with [Cursor](https://cursor.com)