### PR TITLE
hardening(policy): document defaults and fail zlint closed

### DIFF
--- a/policies/cabf_policy.yaml
+++ b/policies/cabf_policy.yaml
@@ -44,15 +44,21 @@ domains:
     - ".intranet"
 
 lint:
+  # Default profile remains tool-portable for local/offline runs; CI lint profile
+  # (`policies/profiles/ci_lint_gate.yaml`) enforces zlint with fail-closed behavior.
   enable_zlint: false
   fail_on_error: true
   fail_severities:
     - "error"
     - "fatal"
+  # Disabled in baseline profile to avoid OpenSSL CLI dependency for local dry runs.
+  # Enabled in CI lint profile where the binary is installed and version-pinned.
   enable_asn1parse: false
   fail_on_asn1_error: true
 
 dcv:
+  # Staged rollout: baseline enforces cert structure first. Set true when your
+  # issuance pipeline consistently provides `--dcv-attestation` evidence.
   required: false
   allowed_methods:
     - "dns-01"
@@ -61,6 +67,8 @@ dcv:
   max_age_days: 30
 
 rfc5280:
+  # Optional strict-profile checks are disabled in baseline for gradual adoption.
+  # Enable in hardened profiles when issuer-chain evidence is available in CI.
   require_end_entity_not_ca: false
   require_key_usage: false
   required_key_usages:
@@ -77,16 +85,21 @@ rfc5280:
   require_path_aki_ski_match: false
 
 opa:
+  # OPA gate is optional in baseline; enabled in CI lint profile for policy-as-code.
   enabled: false
   policy_file: "policies/rego/validity.rego"
 
 issuance:
+  # Disabled until issuance attestation plumbing is consistently available.
   require_hsm_attestation: false
   min_fips_level: 2
 
 crypto_transition:
+  # Transition profile stays opt-in; enable when your program explicitly enforces
+  # post-baseline crypto agility controls in issuance.
   enabled: false
-  target_max_validity_days: 90
+  # CABF staged validity direction is 200 -> 100 -> 47 days; use 47 as end-state target.
+  target_max_validity_days: 47
   target_min_rsa_bits: 3072
   approved_signature_algorithms:
     - "sha256"

--- a/src/certguard/engine.py
+++ b/src/certguard/engine.py
@@ -432,7 +432,23 @@ class ComplianceGateEngine:
                 cmd, capture_output=True, text=True, check=False
             )
         except FileNotFoundError:
-            return {"status": "skipped", "details": "zlint not installed"}
+            return {
+                "tool": "zlint",
+                "status": "fail",
+                "return_code": None,
+                "details": "zlint binary not installed while lint.enable_zlint=true.",
+                "summary": {
+                    "fail_severities": sorted(
+                        {
+                            self._normalize_severity(value)
+                            for value in lint_cfg.get("fail_severities", ["error", "fatal"])
+                        }
+                    ),
+                    "counts": {},
+                    "matched_failures": [],
+                },
+                "raw_output": "",
+            }
 
         fail_severities = {
             self._normalize_severity(value)

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -83,3 +83,33 @@ def test_zlint_fallback_honors_fail_on_error(monkeypatch, tmp_path: Path) -> Non
 
     assert result["status"] == "pass"
     assert result["details"].startswith("zlint output not parseable")
+
+
+def test_zlint_fallback_fails_when_fail_on_error_enabled(monkeypatch, tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.yaml"
+    _write_policy(policy_path, fail_severities=["error"], fail_on_error=True)
+    engine = ComplianceGateEngine(policy_path=policy_path)
+
+    def _fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=1, stdout="not-json", stderr="bad output")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = engine._run_zlint_if_enabled(Path("tests/certificates/valid_cert.pem"))
+
+    assert result["status"] == "fail"
+    assert result["details"].startswith("zlint output not parseable")
+
+
+def test_zlint_missing_binary_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.yaml"
+    _write_policy(policy_path, fail_severities=["error", "fatal"], enable_zlint=True)
+    engine = ComplianceGateEngine(policy_path=policy_path)
+
+    def _missing_binary(*args, **kwargs):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(subprocess, "run", _missing_binary)
+    result = engine._run_zlint_if_enabled(Path("tests/certificates/valid_cert.pem"))
+
+    assert result["status"] == "fail"
+    assert "not installed" in result["details"]


### PR DESCRIPTION
## Summary
- add per-field rationale comments for baseline disabled controls in `policies/cabf_policy.yaml`
- align `crypto_transition.target_max_validity_days` with staged BR direction (200 -> 100 -> 47)
- fail closed when `lint.enable_zlint=true` but zlint is missing, and add fallback regression tests

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_linting.py tests/test_policy.py tests/test_phase4_features.py`

Made with [Cursor](https://cursor.com)