### PR TITLE
feat(audit): add decision log integrity verifier

### DIFF
--- a/src/certguard/engine.py
+++ b/src/certguard/engine.py
@@ -180,6 +180,54 @@ class ComplianceGateEngine:
                 return entry_hash
         return None
 
+    def verify_decision_log_integrity(
+        self, decision_log_path: Path
+    ) -> tuple[bool, str]:
+        if not decision_log_path.exists():
+            return False, f"Decision log not found: {decision_log_path}"
+
+        lines = [line for line in decision_log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        if not lines:
+            return False, "Decision log is empty."
+
+        previous_hash: str | None = None
+        for index, line in enumerate(lines, start=1):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                return False, f"Line {index} is not valid JSON."
+            if not isinstance(entry, dict):
+                return False, f"Line {index} must be a JSON object."
+
+            entry_hash = entry.get("entry_hash")
+            if not isinstance(entry_hash, str) or not entry_hash:
+                return False, f"Line {index} is missing a valid entry_hash."
+
+            recorded_previous = entry.get("previous_entry_hash")
+            if recorded_previous != previous_hash:
+                return (
+                    False,
+                    f"Line {index} previous_entry_hash mismatch: "
+                    f"expected {previous_hash}, got {recorded_previous}.",
+                )
+
+            canonical_entry = dict(entry)
+            canonical_entry.pop("entry_hash", None)
+            canonical = json.dumps(
+                canonical_entry, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+            recomputed = hashlib.sha256(canonical).hexdigest()
+            if recomputed != entry_hash:
+                return (
+                    False,
+                    f"Line {index} entry_hash mismatch: expected {entry_hash}, "
+                    f"recomputed {recomputed}.",
+                )
+
+            previous_hash = entry_hash
+
+        return True, "Decision log integrity verified."
+
     def _run_opa_if_enabled(self, parser_data: dict[str, Any]) -> dict[str, Any]:
         opa_cfg = self.policy.get("opa", {})
         if not opa_cfg.get("enabled", False):

--- a/tests/test_audit_decision_log.py
+++ b/tests/test_audit_decision_log.py
@@ -37,3 +37,58 @@ def test_compliance_decision_log_written_and_chained(tmp_path: Path) -> None:
     assert entries[1]["entry_hash"]
     assert entries[0]["previous_entry_hash"] is None
     assert entries[1]["previous_entry_hash"] == entries[0]["entry_hash"]
+
+
+def test_verify_decision_log_integrity_passes_for_untampered_log(tmp_path: Path) -> None:
+    engine = ComplianceGateEngine(policy_path=Path("policies/cabf_policy.yaml"))
+    evidence_dir = tmp_path / "audit_evidence"
+
+    engine.evaluate(
+        cert_path=Path("tests/certificates/valid_cert.pem"),
+        report_path=tmp_path / "report_1.json",
+        evidence_dir=evidence_dir,
+    )
+    engine.evaluate(
+        cert_path=Path("tests/certificates/sha1_cert.pem"),
+        report_path=tmp_path / "report_2.json",
+        evidence_dir=evidence_dir,
+    )
+
+    ok, details = engine.verify_decision_log_integrity(
+        evidence_dir / "compliance_decisions.jsonl"
+    )
+    assert ok is True
+    assert "verified" in details.lower()
+
+
+def test_verify_decision_log_integrity_detects_tampered_middle_entry(
+    tmp_path: Path,
+) -> None:
+    engine = ComplianceGateEngine(policy_path=Path("policies/cabf_policy.yaml"))
+    evidence_dir = tmp_path / "audit_evidence"
+
+    engine.evaluate(
+        cert_path=Path("tests/certificates/valid_cert.pem"),
+        report_path=tmp_path / "report_1.json",
+        evidence_dir=evidence_dir,
+    )
+    engine.evaluate(
+        cert_path=Path("tests/certificates/sha1_cert.pem"),
+        report_path=tmp_path / "report_2.json",
+        evidence_dir=evidence_dir,
+    )
+    engine.evaluate(
+        cert_path=Path("tests/certificates/no_san_cert.pem"),
+        report_path=tmp_path / "report_3.json",
+        evidence_dir=evidence_dir,
+    )
+
+    log_path = evidence_dir / "compliance_decisions.jsonl"
+    entries = _read_jsonl(log_path)
+    entries[1]["compliant"] = True
+    tampered_lines = [json.dumps(entry, sort_keys=True) for entry in entries]
+    log_path.write_text("\n".join(tampered_lines) + "\n", encoding="utf-8")
+
+    ok, details = engine.verify_decision_log_integrity(log_path)
+    assert ok is False
+    assert "entry_hash mismatch" in details


### PR DESCRIPTION
## Summary
- add `verify_decision_log_integrity()` to independently validate hash-chain integrity in `compliance_decisions.jsonl`
- detect malformed JSON entries, broken previous-hash links, and entry hash mismatches
- add regression tests for clean log verification and tampered middle-entry detection

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_audit_decision_log.py tests/test_phase4_features.py`

Made with [Cursor](https://cursor.com)