### PR TITLE
ci(supply-chain): add cosign keyless provenance signing

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   checks: write
+  id-token: write
 
 concurrency:
   group: compliance-${{ github.workflow }}-${{ github.ref }}
@@ -38,6 +39,9 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Install dependencies
         run: |
@@ -155,13 +159,11 @@ jobs:
             --output-reproducible \
             --output-file reports/sbom.cdx.json
 
-      - name: Generate signed release provenance + verify signature
+      - name: Generate release provenance manifest
         run: |
           python - <<'PY'
           from pathlib import Path
-          from certguard.artifact_signing import generate_ed25519_keypair_b64
           from certguard.release_provenance import generate_release_provenance
-          from certguard.release_provenance import verify_release_provenance_signature
           artifacts = [
               Path("reports/compliance_report.json"),
               Path("reports/compliance_report.json.seal"),
@@ -175,26 +177,33 @@ jobs:
               Path("audit_evidence/evidence_manifest.json"),
               Path("audit_evidence/compliance_decisions.jsonl"),
           ]
-          private_key_b64, public_key_b64 = generate_ed25519_keypair_b64()
           manifest_path, _, signature_path = generate_release_provenance(
               artifact_paths=artifacts,
               output_path=Path("reports/release_provenance.json"),
-              signing_private_key_b64=private_key_b64,
-              signing_public_key_b64=public_key_b64,
           )
-          if signature_path is None:
-              raise SystemExit("Expected signed provenance output, got none.")
-          if not verify_release_provenance_signature(
-              manifest_path,
-              signature_path,
-              public_key_b64,
-          ):
-              raise SystemExit("Release provenance signature verification failed.")
-          Path("reports/release_signing_public_key.b64").write_text(
-              public_key_b64,
-              encoding="utf-8",
-          )
+          if signature_path is not None:
+              raise SystemExit("Expected unsigned provenance manifest before keyless signing.")
+          if not manifest_path.exists():
+              raise SystemExit("Release provenance manifest was not created.")
           PY
+
+      - name: Sign provenance with cosign keyless
+        run: |
+          cosign sign-blob --yes \
+            --bundle reports/release_provenance.cosign.bundle \
+            --output-certificate reports/release_provenance.cosign.crt \
+            --output-signature reports/release_provenance.cosign.sig \
+            reports/release_provenance.json
+
+      - name: Verify cosign signature and identity
+        run: |
+          cosign verify-blob \
+            --bundle reports/release_provenance.cosign.bundle \
+            --certificate reports/release_provenance.cosign.crt \
+            --signature reports/release_provenance.cosign.sig \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/(heads/.+|pull/.+/merge)$' \
+            reports/release_provenance.json
 
       - name: Prepare traceable artifact bundle
         run: |
@@ -206,9 +215,9 @@ jobs:
           cp reports/sbom.cdx.json "artifacts/${GITHUB_RUN_ID}/"
           cp reports/release_provenance.json "artifacts/${GITHUB_RUN_ID}/"
           cp reports/release_provenance.json.digest "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.json.sig "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.json.sig.meta.json "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_signing_public_key.b64 "artifacts/${GITHUB_RUN_ID}/"
+          cp reports/release_provenance.cosign.sig "artifacts/${GITHUB_RUN_ID}/"
+          cp reports/release_provenance.cosign.crt "artifacts/${GITHUB_RUN_ID}/"
+          cp reports/release_provenance.cosign.bundle "artifacts/${GITHUB_RUN_ID}/"
           cp reports/test-results/pytest-junit.xml "artifacts/${GITHUB_RUN_ID}/"
           cp reports/test-results/pytest-report.html "artifacts/${GITHUB_RUN_ID}/"
           cp audit_evidence/policy_checks.json "artifacts/${GITHUB_RUN_ID}/"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ flowchart LR
 - Code analysis: `.github/workflows/codeql.yml`
 - Secret detection: `.github/workflows/secrets-scan.yml`
 - IaC scan (Kubernetes manifests): `.github/workflows/iac-scan.yml`
+- Keyless provenance signing (OIDC + Rekor): `.github/workflows/compliance.yml`
 - API TLS posture checks: `--mode apisec`
 - Controlled exceptions: `--waiver-file` (ticket + expiry required)
 
@@ -103,6 +104,15 @@ python src/main.py --mode apisec --endpoint https://example.com
   - `pytest-junit.xml`
   - `pytest-report.html` (self-contained HTML report)
 - Evidence reports are CI-generated; local `reports/test-results/` is intentionally git-ignored.
+
+## Provenance Verification
+
+- `Compliance Gate` signs `release_provenance.json` with cosign keyless signing.
+- Verification uses GitHub OIDC identity and Rekor transparency-log proof, not a co-located static key.
+- Evidence bundle includes:
+  - `release_provenance.cosign.sig`
+  - `release_provenance.cosign.crt`
+  - `release_provenance.cosign.bundle`
 
 ## CI Workflows
 

--- a/docs/EVIDENCE_LIFECYCLE.md
+++ b/docs/EVIDENCE_LIFECYCLE.md
@@ -27,9 +27,9 @@ CI bundles evidence under a run-specific path:
 - `artifacts/<github_run_id>/sbom.cdx.json`
 - `artifacts/<github_run_id>/release_provenance.json`
 - `artifacts/<github_run_id>/release_provenance.json.digest`
-- `artifacts/<github_run_id>/release_provenance.json.sig`
-- `artifacts/<github_run_id>/release_provenance.json.sig.meta.json`
-- `artifacts/<github_run_id>/release_signing_public_key.b64`
+- `artifacts/<github_run_id>/release_provenance.cosign.sig`
+- `artifacts/<github_run_id>/release_provenance.cosign.crt`
+- `artifacts/<github_run_id>/release_provenance.cosign.bundle`
 
 This provides deterministic traceability from evidence to workflow execution context.
 
@@ -47,5 +47,6 @@ This provides deterministic traceability from evidence to workflow execution con
 4. Verify waiver application (`waiver_results.json`).
 5. Review decision log integrity (`compliance_decisions.jsonl` hash chain).
 6. Review trend signal (`compliance_trend_snapshot.json`).
-7. Verify release provenance signature (`release_provenance.json.sig` against public key).
+7. Verify release provenance signature with cosign keyless identity validation:
+   - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/(heads/.+|pull/.+/merge)$' release_provenance.json`
 8. Record reviewer note in PR or issue using `compliance_summary.md`.


### PR DESCRIPTION
## Summary
- switch provenance signing in `Compliance Gate` from co-located key material to cosign keyless signing
- verify provenance signature using GitHub OIDC issuer + workflow identity regex in CI
- publish cosign signature/certificate/bundle artifacts and update verification docs in README + evidence lifecycle

## Test plan
- [x] Validate updated workflow YAML parses successfully
- [ ] Confirm PR checks pass in GitHub Actions (including new cosign sign/verify steps)

Made with [Cursor](https://cursor.com)