### PR TITLE
chore(supply-chain): tighten keyless identity binding docs

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -195,6 +195,14 @@ jobs:
             --output-signature reports/release_provenance.cosign.sig \
             reports/release_provenance.json
 
+      - name: Resolve expected workflow identity
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "COSIGN_CERT_IDENTITY_REGEX=^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$" >> "$GITHUB_ENV"
+          else
+            echo "COSIGN_CERT_IDENTITY_REGEX=^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$" >> "$GITHUB_ENV"
+          fi
+
       - name: Verify cosign signature and identity
         run: |
           cosign verify-blob \
@@ -202,7 +210,7 @@ jobs:
             --certificate reports/release_provenance.cosign.crt \
             --signature reports/release_provenance.cosign.sig \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/(heads/.+|pull/.+/merge)$' \
+            --certificate-identity-regexp "${COSIGN_CERT_IDENTITY_REGEX}" \
             reports/release_provenance.json
 
       - name: Prepare traceable artifact bundle

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ python src/main.py --mode apisec --endpoint https://example.com
   - `release_provenance.cosign.sig`
   - `release_provenance.cosign.crt`
   - `release_provenance.cosign.bundle`
+- Independent verification command (outside CI):
+  - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' release_provenance.json`
+- For PR workflow runs, replace identity regex with:
+  - `^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$`
+- The cosign bundle is retained as portability evidence so provenance can be re-verified later without relying on repo-stored keys.
 
 ## CI Workflows
 

--- a/docs/EVIDENCE_LIFECYCLE.md
+++ b/docs/EVIDENCE_LIFECYCLE.md
@@ -33,6 +33,11 @@ CI bundles evidence under a run-specific path:
 
 This provides deterministic traceability from evidence to workflow execution context.
 
+### Trust model scope
+
+- Runs using cosign keyless artifacts (`release_provenance.cosign.*`) are verified with GitHub OIDC identity + Rekor proof.
+- Older runs that only contain `release_signing_public_key.b64` / `release_provenance.json.sig` used the legacy co-located key model and are outside the keyless trust scope.
+
 ## Retention Guidance
 
 - Keep evidence artifacts for at least one sprint cycle for engineering review.
@@ -48,5 +53,6 @@ This provides deterministic traceability from evidence to workflow execution con
 5. Review decision log integrity (`compliance_decisions.jsonl` hash chain).
 6. Review trend signal (`compliance_trend_snapshot.json`).
 7. Verify release provenance signature with cosign keyless identity validation:
-   - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/(heads/.+|pull/.+/merge)$' release_provenance.json`
+   - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' release_provenance.json`
+   - For PR workflow evidence, use `^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$`.
 8. Record reviewer note in PR or issue using `compliance_summary.md`.


### PR DESCRIPTION
## Summary
- tighten cosign verification identity binding based on workflow event context (`main` vs `pull_request` refs)
- add copy-paste independent verification commands to README
- document trust-model scope distinction between keyless and legacy pre-cosign provenance artifacts

## Test plan
- [x] Validate `compliance.yml` YAML parses successfully
- [ ] Confirm PR checks pass in GitHub Actions

Made with [Cursor](https://cursor.com)