### PR TITLE
fix(provenance): restrict release signing to main pushes

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -160,6 +160,7 @@ jobs:
             --output-file reports/sbom.cdx.json
 
       - name: Generate release provenance manifest
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -188,6 +189,7 @@ jobs:
           PY
 
       - name: Sign provenance with cosign keyless
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           cosign sign-blob --yes \
             --bundle reports/release_provenance.cosign.bundle \
@@ -195,22 +197,15 @@ jobs:
             --output-signature reports/release_provenance.cosign.sig \
             reports/release_provenance.json
 
-      - name: Resolve expected workflow identity
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "COSIGN_CERT_IDENTITY_REGEX=^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$" >> "$GITHUB_ENV"
-          else
-            echo "COSIGN_CERT_IDENTITY_REGEX=^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$" >> "$GITHUB_ENV"
-          fi
-
       - name: Verify cosign signature and identity
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           cosign verify-blob \
             --bundle reports/release_provenance.cosign.bundle \
             --certificate reports/release_provenance.cosign.crt \
             --signature reports/release_provenance.cosign.sig \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            --certificate-identity-regexp "${COSIGN_CERT_IDENTITY_REGEX}" \
+            --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' \
             reports/release_provenance.json
 
       - name: Prepare traceable artifact bundle
@@ -221,11 +216,13 @@ jobs:
           cp reports/compliance_summary.md "artifacts/${GITHUB_RUN_ID}/"
           cp reports/compliance_trend_snapshot.json "artifacts/${GITHUB_RUN_ID}/"
           cp reports/sbom.cdx.json "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.json "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.json.digest "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.cosign.sig "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.cosign.crt "artifacts/${GITHUB_RUN_ID}/"
-          cp reports/release_provenance.cosign.bundle "artifacts/${GITHUB_RUN_ID}/"
+          if [ -f reports/release_provenance.json ]; then
+            cp reports/release_provenance.json "artifacts/${GITHUB_RUN_ID}/"
+            cp reports/release_provenance.json.digest "artifacts/${GITHUB_RUN_ID}/"
+            cp reports/release_provenance.cosign.sig "artifacts/${GITHUB_RUN_ID}/"
+            cp reports/release_provenance.cosign.crt "artifacts/${GITHUB_RUN_ID}/"
+            cp reports/release_provenance.cosign.bundle "artifacts/${GITHUB_RUN_ID}/"
+          fi
           cp reports/test-results/pytest-junit.xml "artifacts/${GITHUB_RUN_ID}/"
           cp reports/test-results/pytest-report.html "artifacts/${GITHUB_RUN_ID}/"
           cp audit_evidence/policy_checks.json "artifacts/${GITHUB_RUN_ID}/"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ python src/main.py --mode apisec --endpoint https://example.com
 
 ## Provenance Verification
 
-- `Compliance Gate` signs `release_provenance.json` with cosign keyless signing.
+- `Compliance Gate` signs `release_provenance.json` with cosign keyless signing only on `push` to `main` (release context).
 - Verification uses GitHub OIDC identity and Rekor transparency-log proof, not a co-located static key.
 - Evidence bundle includes:
   - `release_provenance.cosign.sig`
@@ -115,8 +115,6 @@ python src/main.py --mode apisec --endpoint https://example.com
   - `release_provenance.cosign.bundle`
 - Independent verification command (outside CI):
   - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' release_provenance.json`
-- For PR workflow runs, replace identity regex with:
-  - `^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$`
 - The cosign bundle is retained as portability evidence so provenance can be re-verified later without relying on repo-stored keys.
 
 ## CI Workflows

--- a/docs/EVIDENCE_LIFECYCLE.md
+++ b/docs/EVIDENCE_LIFECYCLE.md
@@ -36,6 +36,7 @@ This provides deterministic traceability from evidence to workflow execution con
 ### Trust model scope
 
 - Runs using cosign keyless artifacts (`release_provenance.cosign.*`) are verified with GitHub OIDC identity + Rekor proof.
+- `release_provenance.*` is generated only for release-context workflow executions (`push` to `main`).
 - Older runs that only contain `release_signing_public_key.b64` / `release_provenance.json.sig` used the legacy co-located key model and are outside the keyless trust scope.
 
 ## Retention Guidance
@@ -54,5 +55,4 @@ This provides deterministic traceability from evidence to workflow execution con
 6. Review trend signal (`compliance_trend_snapshot.json`).
 7. Verify release provenance signature with cosign keyless identity validation:
    - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' release_provenance.json`
-   - For PR workflow evidence, use `^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/pull/[0-9]+/merge$`.
 8. Record reviewer note in PR or issue using `compliance_summary.md`.


### PR DESCRIPTION
## Summary
- gate release provenance generation/signing/verification to `push` on `main` only
- prevent PR workflow runs from producing `release_provenance.*` artifacts
- update docs to reflect release-context scope for signed provenance claims

## Test plan
- [x] Validate updated workflow YAML parses successfully
- [ ] Confirm PR checks pass in GitHub Actions

Made with [Cursor](https://cursor.com)