### PR TITLE
ci(attestation): publish GitHub native provenance attestations

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -19,6 +19,7 @@ permissions:
   contents: read
   checks: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: compliance-${{ github.workflow }}-${{ github.ref }}
@@ -207,6 +208,12 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' \
             reports/release_provenance.json
+
+      - name: Publish GitHub build attestation
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: reports/release_provenance.json
 
       - name: Prepare traceable artifact bundle
         run: |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ python src/main.py --mode apisec --endpoint https://example.com
 ## Provenance Verification
 
 - `Compliance Gate` signs `release_provenance.json` with cosign keyless signing only on `push` to `main` (release context).
+- `Compliance Gate` also publishes a GitHub native build attestation for `release_provenance.json` on `push` to `main`.
 - Verification uses GitHub OIDC identity and Rekor transparency-log proof, not a co-located static key.
 - Evidence bundle includes:
   - `release_provenance.cosign.sig`
@@ -116,6 +117,7 @@ python src/main.py --mode apisec --endpoint https://example.com
 - Independent verification command (outside CI):
   - `cosign verify-blob --bundle release_provenance.cosign.bundle --certificate release_provenance.cosign.crt --signature release_provenance.cosign.sig --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp '^https://github.com/thulisa-n/pki-compliance-gate/.github/workflows/compliance.yml@refs/heads/main$' release_provenance.json`
 - The cosign bundle is retained as portability evidence so provenance can be re-verified later without relying on repo-stored keys.
+- GitHub-native attestations are visible in the repository **Attestations** tab for release-context runs.
 
 ## CI Workflows
 

--- a/docs/EVIDENCE_LIFECYCLE.md
+++ b/docs/EVIDENCE_LIFECYCLE.md
@@ -30,6 +30,7 @@ CI bundles evidence under a run-specific path:
 - `artifacts/<github_run_id>/release_provenance.cosign.sig`
 - `artifacts/<github_run_id>/release_provenance.cosign.crt`
 - `artifacts/<github_run_id>/release_provenance.cosign.bundle`
+- GitHub native attestation entry (repository Attestations tab) for `release_provenance.json`
 
 This provides deterministic traceability from evidence to workflow execution context.
 
@@ -37,6 +38,7 @@ This provides deterministic traceability from evidence to workflow execution con
 
 - Runs using cosign keyless artifacts (`release_provenance.cosign.*`) are verified with GitHub OIDC identity + Rekor proof.
 - `release_provenance.*` is generated only for release-context workflow executions (`push` to `main`).
+- GitHub native attestation publication for `release_provenance.json` is also limited to `push` on `main`.
 - Older runs that only contain `release_signing_public_key.b64` / `release_provenance.json.sig` used the legacy co-located key model and are outside the keyless trust scope.
 
 ## Retention Guidance


### PR DESCRIPTION
## Summary
- add GitHub native build attestation publishing for `release_provenance.json`
- scope publication to `push` on `main` to preserve release-context semantics
- keep existing cosign/Rekor keyless signing flow and document both attestation surfaces

## Test plan
- [x] Validate updated workflow YAML parses successfully
- [ ] Confirm PR checks pass and verify Attestations tab after merge/main run

Made with [Cursor](https://cursor.com)