### PR TITLE
chore(standards): sync CAB Forum baseline snapshot

### DIFF
--- a/policies/standards_baseline.yaml
+++ b/policies/standards_baseline.yaml
@@ -1,8 +1,8 @@
 terms: []
 baseline:
   source: CA/Browser Forum BR (auto-synced)
-  version: 2026.07.07
-  last_reviewed: '2026-07-07'
+  version: 2026.07.14
+  last_reviewed: '2026-07-14'
   references:
   - CAB Forum Baseline Requirements
   - RFC 5280

--- a/policies/standards_sync_snapshot.yaml
+++ b/policies/standards_sync_snapshot.yaml
@@ -1,5 +1,5 @@
 sync:
-  fetched_at: '2026-07-07T09:18:36.705882+00:00'
+  fetched_at: '2026-07-14T07:42:40.829760+00:00'
   source_url: https://raw.githubusercontent.com/cabforum/servercert/a0f0a3ca5dfeaa53c682dded3d0d9dd49e3609b7/docs/BR.md
   source_sha256: a29be59f0ae0485be505f30281b356a0efef2a2ad442daf9a9f161f2df238f67
 extracted:


### PR DESCRIPTION
## Summary
- sync CA/B Forum BR snapshot from upstream source
- refresh `policies/standards_baseline.yaml`
- update generated `policies/standards_sync_snapshot.yaml`
- note: auto-run PR checks require `STANDARDS_SYNC_PR_TOKEN` secret